### PR TITLE
[Docs]: Add API Documentation for Auth Logout Endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -400,6 +400,50 @@
                 }
             }
         },
+        "/auth/signout": {
+            "delete": {
+                "tags": ["Auth", "User"],
+                "summary": "User signout",
+                "description": "Logout for the user",
+                "responses": {
+                    "200": {
+                        "description": "Success signout user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "Example Logout": {
+                                        "description": "Success logout",
+                                        "value": {
+                                            "status": "success",
+                                            "message": "Logout successfully"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ]
+            }
+        },
         "/token/refresh": {
             "get": {
                 "tags": ["Auth", "User", "Token"],


### PR DESCRIPTION
This pull request add API Documentation related to the:

- Auth (logout)

# List endpoint:

- Auth

| Endpoint | Method | Description |
| -- | -- | -- |
| `/auth/signout` | DELETE | User signout |
